### PR TITLE
[#10] 멘토생성 기능구현 및 테스트코드

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc")
 
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
@@ -38,6 +39,9 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    runtimeOnly("com.mysql:mysql-connector-j")
+    runtimeOnly("com.h2database:h2")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/joonhee/moneygate/mentor/application/repository/MentorRepositoryImpl.java
+++ b/src/main/java/com/joonhee/moneygate/mentor/application/repository/MentorRepositoryImpl.java
@@ -1,0 +1,112 @@
+package com.joonhee.moneygate.mentor.application.repository;
+
+import com.joonhee.moneygate.mentor.domain.entity.Mentor;
+import com.joonhee.moneygate.mentor.domain.repository.MentorRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Repository
+public class MentorRepositoryImpl implements MentorRepository {
+    private final DataSource dataSource;
+
+    public MentorRepositoryImpl(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public Mentor save(Mentor mentor) {
+        String sql = "insert into mentor(email, nick_name, profile_image, created_at) values (?, ?, ?, ?)";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+
+            // Use Statement.RETURN_GENERATED_KEYS to retrieve the generated ID
+            pstmt = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            pstmt.setString(1, mentor.getEmail());
+            pstmt.setString(2, mentor.getNickName());
+            pstmt.setString(3, mentor.getProfileImage());
+            pstmt.setTimestamp(4, Timestamp.from(mentor.getCreatedAt().toInstant()));
+
+            int affectedRows = pstmt.executeUpdate();  // Execute the insert
+            if (affectedRows > 0) {
+                rs = pstmt.getGeneratedKeys();  // Retrieve the generated keys (ID)
+                if (rs.next()) {
+                    mentor.setId(rs.getLong(1));  // Set the generated ID
+                }
+            }
+            return mentor;  // Return the mentor object with the ID set
+        } catch (SQLException e) {
+            log.error("db error", e);
+            throw new RuntimeException(e);
+        } finally {
+            close(con, pstmt, rs);  // Ensure all resources are closed
+        }
+    }
+
+    @Override
+    public Mentor findById(Long id) {
+        String sql = "select * from mentor where mentor_id = ?";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setLong(1, id);
+
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                Mentor member = new Mentor(
+                    rs.getLong("mentor_id"),
+                    rs.getString("email"),
+                    rs.getString("nick_name"),
+                    rs.getString("profile_image"),
+                    ZonedDateTime.ofInstant(rs.getTimestamp("created_at").toInstant(), ZoneId.systemDefault()),
+                    getTimeStamp(rs.getTimestamp("updated_at"))
+                );
+                return member;
+            } else {
+                throw new NoSuchElementException("mentor not found mentor_id=" + id);
+            }
+
+        } catch (SQLException e) {
+            log.error("db error", e);
+            throw new RuntimeException(e);
+        } finally {
+            close(con, pstmt, rs);
+        }
+    }
+
+    private ZonedDateTime getTimeStamp(Timestamp timeStamp) {
+        if (timeStamp == null) {
+            return null;
+        }
+        return ZonedDateTime.ofInstant(timeStamp.toInstant(), ZoneId.systemDefault());
+    }
+
+    private void close(Connection con, Statement stmt, ResultSet rs) {
+        JdbcUtils.closeResultSet(rs);
+        JdbcUtils.closeStatement(stmt);
+        JdbcUtils.closeConnection(con);
+    }
+
+
+    private Connection getConnection() throws SQLException {
+        Connection con = DataSourceUtils.getConnection(dataSource);
+        return con;
+    }
+}

--- a/src/main/java/com/joonhee/moneygate/mentor/domain/entity/Mentor.java
+++ b/src/main/java/com/joonhee/moneygate/mentor/domain/entity/Mentor.java
@@ -1,18 +1,33 @@
 package com.joonhee.moneygate.mentor.domain.entity;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+
+@Getter
 public class Mentor {
+    @Setter
     private Long id;
     private final String email;
     private final String nickName;
     private final String profileImage;
+    private final ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
 
-    public Mentor(String nickName, String email,String profileImage) {
+    public Mentor(String nickName, String email, String profileImage) {
         this.email = email;
         this.nickName = nickName;
         this.profileImage = profileImage;
+        this.createdAt = ZonedDateTime.now();
     }
 
-    public Long getMentorId() {
-        return id;
+    public Mentor(Long id, String nickName, String email, String profileImage, ZonedDateTime createdAt, ZonedDateTime updatedAt) {
+        this.id = id;
+        this.email = email;
+        this.nickName = nickName;
+        this.profileImage = profileImage;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/joonhee/moneygate/mentor/domain/service/CreateMentorService.java
+++ b/src/main/java/com/joonhee/moneygate/mentor/domain/service/CreateMentorService.java
@@ -1,0 +1,24 @@
+package com.joonhee.moneygate.mentor.domain.service;
+
+import com.joonhee.moneygate.mentor.domain.entity.Mentor;
+import com.joonhee.moneygate.mentor.domain.repository.MentorRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateMentorService {
+    private final MentorRepository mentorRepository;
+
+    public CreateMentorService(MentorRepository mentorRepository) {
+        this.mentorRepository = mentorRepository;
+    }
+
+    public Long createMentor(String nickName, String email, String profileImage) {
+        Mentor mentor = new Mentor(nickName, email, profileImage);
+        mentorRepository.save(mentor);
+        return mentor.getId();
+    }
+
+    public Mentor findById(Long id) {
+        return mentorRepository.findById(id);
+    }
+}

--- a/src/main/java/com/joonhee/moneygate/mentor/domain/service/QueryMentorService.java
+++ b/src/main/java/com/joonhee/moneygate/mentor/domain/service/QueryMentorService.java
@@ -1,0 +1,18 @@
+package com.joonhee.moneygate.mentor.domain.service;
+
+import com.joonhee.moneygate.mentor.domain.entity.Mentor;
+import com.joonhee.moneygate.mentor.domain.repository.MentorRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class QueryMentorService {
+    private final MentorRepository mentorRepository;
+
+    public QueryMentorService(MentorRepository mentorRepository) {
+        this.mentorRepository = mentorRepository;
+    }
+
+    public Mentor findById(Long id) {
+        return mentorRepository.findById(id);
+    }
+}

--- a/src/main/java/com/joonhee/moneygate/newsfeed/domain/entity/NewsFeed.java
+++ b/src/main/java/com/joonhee/moneygate/newsfeed/domain/entity/NewsFeed.java
@@ -29,7 +29,7 @@ public class NewsFeed {
     }
 
     public Long getMentorId() {
-        return mentor.getMentorId();
+        return mentor.getId();
     }
 
     public String getBody() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,11 @@ springdoc:
     path:"/swagger"
 
 spring:
+  datasource:
+    url: jdbc:mysql://localhost:13306/dev
+    username: joonhee
+    password: 1234
+
   cloud:
     openfeign:
       client:

--- a/src/main/resources/sql/mentor.sql
+++ b/src/main/resources/sql/mentor.sql
@@ -1,0 +1,13 @@
+CREATE TABLE mentor
+(
+    mentor_id     BIGINT AUTO_INCREMENT NOT NULL COMMENT '인덱싱 컬럼',
+    email         VARCHAR(100)  NOT NULL COMMENT '로그인 이메일',
+    nick_name     VARCHAR(100) NOT NULL COMMENT '멘토 이름',
+    profile_image VARCHAR(255) NOT NULL COMMENT '프로필 이미지',
+    created_at    DATETIME     NOT NULL COMMENT '생성일',
+    updated_at    DATETIME     NULL COMMENT '수정일',
+    PRIMARY KEY (mentor_id),
+    CONSTRAINT uc_mentor_email UNIQUE KEY (email),
+    CONSTRAINT uc_mentor_nick_name UNIQUE KEY (nick_name)
+)
+    COLLATE = UTF8MB4_UNICODE_CI;

--- a/src/test/java/com/joonhee/moneygate/mentor/domain/service/CreateMentorServiceIntegrationTest.java
+++ b/src/test/java/com/joonhee/moneygate/mentor/domain/service/CreateMentorServiceIntegrationTest.java
@@ -1,0 +1,28 @@
+package com.joonhee.moneygate.mentor.domain.service;
+
+import com.joonhee.moneygate.mentor.domain.entity.Mentor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CreateMentorServiceIntegrationTest {
+
+    @Autowired
+    CreateMentorService createMentorService;
+    @Autowired
+    QueryMentorService queryMentorService;
+
+    @Test
+    @DisplayName("멘토 등록 테스트")
+    void createMentor() {
+        // Arrange, Action
+        Long mentorId = createMentorService.createMentor("nickName10", "joonhee@abc10.com", "https://image.com");
+        // Assert
+        Mentor mentor = queryMentorService.findById(mentorId);
+        assertThat(mentorId).isEqualTo(mentor.getId());
+    }
+}

--- a/src/test/java/com/joonhee/moneygate/mentor/repository/MemoryMentorRepository.java
+++ b/src/test/java/com/joonhee/moneygate/mentor/repository/MemoryMentorRepository.java
@@ -10,7 +10,7 @@ public class MemoryMentorRepository implements MentorRepository {
 
     @Override
     public Mentor save(Mentor mentor) {
-        mentors.put(mentor.getMentorId(), mentor);
+        mentors.put(mentor.getId(), mentor);
         return mentor;
     }
 

--- a/src/test/java/com/joonhee/moneygate/newsfeed/domain/service/CommandNewsFeedServiceTest.java
+++ b/src/test/java/com/joonhee/moneygate/newsfeed/domain/service/CommandNewsFeedServiceTest.java
@@ -72,7 +72,7 @@ class CommandNewsFeedServiceTest {
                 "joobhee@google.com",
                 "https://avatars.githubusercontent.com/u/77449822?v=4")
         );
-        return this.commandNewsFeedUseCase.createNewsFeed(mentor.getMentorId(), null);
+        return this.commandNewsFeedUseCase.createNewsFeed(mentor.getId(), null);
     }
 
 }


### PR DESCRIPTION
## 📸 이슈번호
- close #10

## 🔬 배경
- 뉴스피드 생성을 하기위해서는 멘토가 먼저 존재해야합니다.

## 🛠 개발 사항
- 멘토를 생성할 수 있는 기능과 조회하는 기능을 개발했습니다.

## ❗️중점적으로 리뷰 받고 싶은 내용
- [ ] JDBC의 순수 기능으로 생성과 조회를 했는데 테스트코드에서 @Transactional 어노테이션이 동작하지 않아서 살펴보니 @Transactional은 Datasource 의 connection을 관리 합니다. repository 구현코드의 finally 에서 커넥션을 닫기 때문에 동작하지 않음을 알 수 있었습니다.
JdbcTemplate로 변경할지 Transaction을 관리하는 aop 를 만들지 알려주시면 감사드립니다.
- [ ] activeProfile 을 환경별로 나누고 테스트시에는 h2 mem 을 쓰는게 좋을까요? 저는 도커로 mysql을 띄워서 쓰는게 좋다고 생각됩니다. 그 이유는 h2 db의 쿼리와 mysql db 쿼리가 달라서 테스트시 정확하지 않다고 생각해서 입니다.

## 🧘‍ 느낀점 또는 깨달은점
- 트랜잭션이 어떤식으로 동작하는지 알아봐야겠다는 생각이 들었습니다.
